### PR TITLE
Travis testing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,3 @@ dependencies:
   - aplpy # used in FITS-cube tutorial
   - spectral-cube # used in FITS-cube tutorial
   - reproject # used in FITS-cube tutorial
-  - dust_extinction # used in color-excess tutorial
-  - synphot # used in color-excess tutorial

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -9,5 +9,3 @@ notebook==5.4
 aplpy
 spectral-cube
 reproject
-dust_extinction
-synphot

--- a/tutorials/notebooks/color-excess/color-excess.ipynb
+++ b/tutorials/notebooks/color-excess/color-excess.ipynb
@@ -168,7 +168,7 @@
         "# For running in Google Colaboratory, uncomment these lines:\n",
         "# !pip install astropy\n",
         "!pip install dust_extinction\n",
-        "# !pip install synphot\n",
+        "!pip install synphot\n",
         "# !pip install astroquery"
       ],
       "execution_count": 2,

--- a/tutorials/notebooks/color-excess/color-excess.ipynb
+++ b/tutorials/notebooks/color-excess/color-excess.ipynb
@@ -167,7 +167,7 @@
       "source": [
         "# For running in Google Colaboratory, uncomment these lines:\n",
         "# !pip install astropy\n",
-        "# !pip install dust_extinction\n",
+        "!pip install dust_extinction\n",
         "# !pip install synphot\n",
         "# !pip install astroquery"
       ],

--- a/tutorials/notebooks/color-excess/requirements.txt
+++ b/tutorials/notebooks/color-excess/requirements.txt
@@ -2,5 +2,6 @@ numpy
 matplotlib
 astropy
 synphot
+dust_extinction
 astroquery
 IPython

--- a/tutorials/notebooks/color-excess/requirements.txt
+++ b/tutorials/notebooks/color-excess/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 matplotlib
 astropy
-dust_extinction
 synphot
 astroquery
 IPython


### PR DESCRIPTION
To resolve the Travis errors of dust_extinction not found, the notebook now explicitly uses `! pip install dust_extinction`.  Adding dust_extinction to requirements.txt didn't seem to made a difference.  Ditto on synphot.